### PR TITLE
[0.6.0] Debuglink abstract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ build/
 
 # coverage
 coverage
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.0] - 06 September 2020.
+- Renamed current `DebugLink` class to `LoggerLink`.
+- Added abstract `DebugLink` class. DebugLinks are special types of links that will never be chained (will be skipped) in release builds. 
 ## [0.5.0] - 05 September 2020.
 * Added cache support.
 * Added id property to ApiRequest and ApiResponse objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.6.0] - 06 September 2020.
 - Renamed current `DebugLink` class to `LoggerLink`.
 - Added abstract `DebugLink` class. DebugLinks are special types of links that will never be chained (will be skipped) in release builds. 
+- Replaced internal `ApiException`s with `ApiError`s.
 ## [0.5.0] - 05 September 2020.
 * Added cache support.
 * Added id property to ApiRequest and ApiResponse objects.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -227,7 +227,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/lib/http_api.dart
+++ b/lib/http_api.dart
@@ -20,10 +20,11 @@ part './src/base_api.dart';
 /// Utils
 part './src/utils/exceptions.dart';
 part './src/utils/api_link.dart';
+part './src/utils/debug_link.dart';
 
 /// Links
 part './src/links/headers_mapper_link.dart';
-part './src/links/debug_link.dart';
+part 'src/links/logger_link.dart';
 part './src/links/http_link.dart';
 
 /// Requests

--- a/lib/src/base_api.dart
+++ b/lib/src/base_api.dart
@@ -27,11 +27,11 @@ abstract class BaseApi {
         this.defaultHeaders = defaultHeaders ?? <String, String>{},
         _link = link._firstLink ?? HttpLink() {
     if (_link._firstWhere((apiLink) => (apiLink is HttpLink)) == null) {
-      throw ApiException("ApiLinks chain should contain HttpLink");
+      throw ApiError("ApiLinks chain should contain HttpLink");
     }
 
     if (_link._firstWhere((apiLink) => apiLink.closed) != null) {
-      throw ApiException("Cannot assign closed ApiLinks chain to $runtimeType");
+      throw ApiError("Cannot assign closed ApiLinks chain to $runtimeType");
     }
 
     /// Close link chain
@@ -62,7 +62,8 @@ abstract class BaseApi {
     ApiRequest request, {
     @experimental bool updateCache = true,
   }) async* {
-    if (request.key == null) throw ApiException('Request key cannot be null');
+    if (request.key == null)
+      throw ApiError('CacheKey is required for requests with cache.');
 
     /// read cache
     final cacheFuture = readCache(request.key);
@@ -92,7 +93,8 @@ abstract class BaseApi {
     ApiRequest request, {
     @experimental bool updateCache = true,
   }) async {
-    if (request.key == null) throw ApiException('Request key cannot be null');
+    if (request.key == null)
+      throw ApiError('CacheKey is required for requests with cache.');
 
     /// get cache
     final cachedResponse = await readCache(request.key);

--- a/lib/src/base_api.dart
+++ b/lib/src/base_api.dart
@@ -25,7 +25,7 @@ abstract class BaseApi {
         assert(url != null, "url $runtimeType argument cannot be null"),
         _url = url,
         this.defaultHeaders = defaultHeaders ?? <String, String>{},
-        _link = link._firstLink ?? link ?? HttpLink() {
+        _link = link._firstLink ?? HttpLink() {
     if (_link._firstWhere((apiLink) => (apiLink is HttpLink)) == null) {
       throw ApiException("ApiLinks chain should contain HttpLink");
     }

--- a/lib/src/links/logger_link.dart
+++ b/lib/src/links/logger_link.dart
@@ -1,5 +1,8 @@
 part of http_api;
 
+/// LoggerLink is DebugLink that prints request details to console.
+/// 
+/// {@macro http_api.debug_link}
 class LoggerLink extends DebugLink {
   final String label;
   final bool url;

--- a/lib/src/links/logger_link.dart
+++ b/lib/src/links/logger_link.dart
@@ -1,6 +1,6 @@
 part of http_api;
 
-class DebugLink extends ApiLink {
+class LoggerLink extends DebugLink {
   final String label;
   final bool url;
   final bool responseBody;
@@ -10,7 +10,7 @@ class DebugLink extends ApiLink {
   final bool statusCode;
   final bool countRequests;
   final bool responseDuration;
-  DebugLink({
+  LoggerLink({
     this.label,
     this.url = false,
     this.requestBody = false,

--- a/lib/src/requests/api_request.dart
+++ b/lib/src/requests/api_request.dart
@@ -22,7 +22,7 @@ class ApiRequest {
   Uri get apiUrl => _apiUrl;
   Uri get url {
     if (apiUrl == null)
-      throw ApiException("url is not available before sending a request");
+      throw ApiError("url is not available before sending a request");
 
     final queryParameters = Map<String, dynamic>.from(apiUrl.queryParameters)
       ..addAll(this.queryParameters);
@@ -75,7 +75,7 @@ class ApiRequest {
   /// Builds http request from ApiRequest data
   FutureOr<http.BaseRequest> build() {
     if (url == null) {
-      throw ApiException("$runtimeType url cannot be null");
+      throw ApiError("$runtimeType url cannot be null. Instead of calling build method, pass ApiRequest to BaseApi: 'send' method.");
     }
     return isMultipart ? _buildMultipartHttpRequest() : _buildHttpRequest();
   }

--- a/lib/src/utils/api_link.dart
+++ b/lib/src/utils/api_link.dart
@@ -72,6 +72,12 @@ abstract class ApiLink {
         "Adding link after http link will take no effect",
       );
 
+    bool isReleaseBuild = true;
+    assert(!(isReleaseBuild = false));
+
+    /// Do not chain (skip) [DebugLink] in release build.
+    if (nextLink is DebugLink && isReleaseBuild) return this;
+
     /// If there is no chain, start it with current
     if (_firstLink == null) {
       _firstLink = this;

--- a/lib/src/utils/debug_link.dart
+++ b/lib/src/utils/debug_link.dart
@@ -1,0 +1,4 @@
+part of http_api;
+
+/// DebugLinks are always skipped in release builds. (They are not chained.)
+abstract class DebugLink extends ApiLink {}

--- a/lib/src/utils/debug_link.dart
+++ b/lib/src/utils/debug_link.dart
@@ -1,4 +1,8 @@
 part of http_api;
 
-/// DebugLinks are always skipped in release builds. (They are not chained.)
+/// To create own dev-only ApiLink, extend this class.
+/// {@template http_api.debug_link}
+///
+/// DebugLinks are always skipped in release builds. They are ignored by [ApiLink.chain] method.
+/// {@endtemplate}
 abstract class DebugLink extends ApiLink {}

--- a/lib/src/utils/exceptions.dart
+++ b/lib/src/utils/exceptions.dart
@@ -6,5 +6,28 @@ class ApiException implements Exception {
 
   String get message => _message;
 
+  String toString() {
+    if (message != null) {
+      return "ApiException: $message";
+    }
+    return "ApiException occured.";
+  }
+
   const ApiException(this._message);
+}
+
+/// Base class for exceptions thrown from the http_api package.
+class ApiError extends Error {
+  final String _message;
+
+  String get message => _message;
+
+  String toString() {
+    if (message != null) {
+      return "ApiError: $message";
+    }
+    return "ApiError occured.";
+  }
+
+  ApiError(this._message) : super();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_api
 description: A simple yet powerful wrapper around http package with middleware support.
-version: 0.5.0
+version: 0.6.0
 repository: https://github.com/gonuit/flutter_http_api
 homepage: https://github.com/gonuit/flutter_http_api
 issue_tracker: https://github.com/gonuit/flutter_http_api/issues

--- a/test/api_link_test.dart
+++ b/test/api_link_test.dart
@@ -60,15 +60,15 @@ void main() {
   });
 
   test("Cannot chain ApiLinks after http link", () {
-    ApiException exception;
+    ApiError error;
     try {
       apiLink.chain(TestLink(99));
-    } on ApiException catch (err) {
-      exception = err;
+    } on ApiError catch (err) {
+      error = err;
     }
-    expect(exception, isNotNull);
+    expect(error, isNotNull);
     expect(
-        exception.message,
+        error.message,
         equals(
           "Cannot chain link HttpLink with TestLink\n"
           "Adding link after http link will take no effect",
@@ -96,18 +96,18 @@ void main() {
   });
 
   test("Cannot reasing ApiLink chain to another api", () async {
-    ApiException exception;
+    ApiError error;
     try {
       TestApi(
         url: testUrl,
         link: apiLink,
       );
-    } on ApiException catch (err) {
-      exception = err;
+    } on ApiError catch (err) {
+      error = err;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.message,
+    expect(error, isNotNull);
+    expect(error.message,
         equals("Cannot assign closed ApiLinks chain to TestApi"));
   });
 
@@ -139,15 +139,15 @@ void main() {
   });
 
   test("Cannot chain ApiLinks after attaching to BaseApi", () {
-    ApiException exception;
+    ApiError error;
     try {
       apiLink.chain(TestLink(99));
-    } on ApiException catch (err) {
-      exception = err;
+    } on ApiError catch (err) {
+      error = err;
     }
-    expect(exception, isNotNull);
+    expect(error, isNotNull);
     expect(
-        exception.message,
+        error.message,
         equals(
           "Cannot chain link HttpLink with TestLink\n"
           "You cannot chain links after attaching to BaseApi",
@@ -155,14 +155,14 @@ void main() {
   });
 
   test("Cannot attach ApiLinks chain without HttpLink", () {
-    ApiException exception;
+    ApiError error;
     try {
       TestApi(url: testUrl, link: TestLink(1).chain(TestLink(2)));
-    } on ApiException catch (err) {
-      exception = err;
+    } on ApiError catch (err) {
+      error = err;
     }
-    expect(exception, isNotNull);
-    expect(exception.message, equals("ApiLinks chain should contain HttpLink"));
+    expect(error, isNotNull);
+    expect(error.message, equals("ApiLinks chain should contain HttpLink"));
   });
 
   test(


### PR DESCRIPTION
### Breaking changes:
- Renamed current `DebugLink` class to `LoggerLink`.
- Added abstract `DebugLink` class. Now `DebugLink` is a special type of `ApiLink` that will never be chained (will be skipped) in release builds. 
- Replaced internal `ApiException`s with `ApiError`s.

Release `0.6.0`